### PR TITLE
Temporary remove `pip check` to avoid failure with numba

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,10 @@ outputs:
       imports:
         - etspy
         - etspy.api
+      # uncomment when etspy >1.0.1 is released
+      # needed to avoid pip check failure with etspy 1.0.1
+      # https://github.com/usnistgov/etspy/pull/35
       # commands:
-      #   # remove when etspy >1.0.1 is released
-      #   # needed to avoid pip check failure with etspy 1.0.1
       #   - pip check
       requires:
         - pip
@@ -59,9 +60,10 @@ outputs:
         - etspy
         - etspy.api
         - cupy
+      # uncomment when etspy >1.0.1 is released
+      # needed to avoid pip check failure with etspy 1.0.1
+      # https://github.com/usnistgov/etspy/pull/35
       # commands:
-      #   # remove when etspy >1.0.1 is released
-      #   # needed to avoid pip check failure with etspy 1.0.1
       #   - pip check
       requires:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,10 @@ outputs:
       imports:
         - etspy
         - etspy.api
-      commands:
-        - pip check
+      # commands:
+      #   # remove when etspy >1.0.1 is released
+      #   # needed to avoid pip check failure with etspy 1.0.1
+      #   - pip check
       requires:
         - pip
   - name: etspy-gpu
@@ -57,8 +59,10 @@ outputs:
         - etspy
         - etspy.api
         - cupy
-      commands:
-        - pip check
+      # commands:
+      #   # remove when etspy >1.0.1 is released
+      #   # needed to avoid pip check failure with etspy 1.0.1
+      #   - pip check
       requires:
         - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b29a782a1f45da2af43d5a086a0ff7ea2b3cff8849b045d86aefa0d9b0da6c0e
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: etspy


### PR DESCRIPTION
The last build failed (https://github.com/conda-forge/etspy-feedstock/runs/39589380827) because the #6 and #7 were merged one after another and the `pip check` test now fails on main.
#6 remove implicitly requirement on numba through hyperspy, because the meta-package hyperspy install numba but hyperspy-base doesn't. #7 remove the explicit dependence on numba and the PR tests passed because it was based on a branch that didn't include #6, i.e. it was still using hyperspy (instead of hyperspy-base) and therefore numba was still installed through hyperspy.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [n/a] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [n/a] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
